### PR TITLE
chore: update node engine to >=24 for active LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "packageManager": "pnpm@10.18.3",
   "engines": {
-    "node": ">=20",
+    "node": ">=24",
     "pnpm": ">=10"
   }
 }


### PR DESCRIPTION
## Summary
- Update node engine requirement from `>=20` to `>=24` to target Node.js 24 active LTS

## Test plan
- [ ] Verify CI passes with Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)